### PR TITLE
Fix count calculation in pivotRepeatingSettings

### DIFF
--- a/UserAgentInfo.php
+++ b/UserAgentInfo.php
@@ -169,7 +169,7 @@ class UserAgentInfo extends \ExternalModules\AbstractExternalModule
         // Now we have a bunch variables with the same number of repeats.  Lets group them:
 
         $map = [];
-        $count = count($keys[0]);
+        $count = count($config[$keys[0]]);
         for ($i = 0; $i <= $count; $i++) {
             $c = [];
             foreach ($keys as $key) {

--- a/UserAgentInfo.php
+++ b/UserAgentInfo.php
@@ -170,7 +170,7 @@ class UserAgentInfo extends \ExternalModules\AbstractExternalModule
 
         $map = [];
         $count = count($config[$keys[0]]);
-        for ($i = 0; $i <= $count; $i++) {
+        for ($i = 0; $i < $count; $i++) {
             $c = [];
             foreach ($keys as $key) {
                 $c[$key] = $config[$key][$i];


### PR DESCRIPTION
the way of calculating $count has been broken since this was published. $count would never have been greater than 1. this will properly check for the count of items under configs["ua__option"] for the proper amount of configs.