### PR TITLE
use array_values to disregard indexes in JSON

### DIFF
--- a/UserAgentInfo.php
+++ b/UserAgentInfo.php
@@ -76,7 +76,7 @@ class UserAgentInfo extends \ExternalModules\AbstractExternalModule
                         "Please notify the project administrator."
                     );
                 } else {
-                    UserAgentInfo.configs = <?php echo json_encode($configs); ?>;
+                    UserAgentInfo.configs = <?php echo json_encode(array_values($configs)); ?>;
                     UserAgentInfo.isDev = <?php echo json_encode((boolean) $this->getProjectSetting('enable-project-debug-logging')); ?>;
                     $(document).ready(function () {
                         UserAgentInfo.init();


### PR DESCRIPTION
because we are `unset`ting an array value (like 0), the remaining indexes (1, 2, 3...) are kept when converting to JSON via json_encode and are treated like an object, not an array. array_values will disregard the indexes and return just the values.