### PR TITLE
remove bad control center link

### DIFF
--- a/config.json
+++ b/config.json
@@ -31,11 +31,6 @@
 
   "links": {
     "control-center": [
-      {
-        "name": "API Whitelist",
-        "icon": "gear",
-        "url": "config.php"
-      }
     ],
     "project": [
     ]


### PR DESCRIPTION
looks like an entry for "API Whitelist" has always existed in this module, linking to a config page that doesn't exist either. best to remove it.